### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/jackyao713911/1aefc37e-fcb0-4ee1-ace2-dc62de3257de/574ef8e2-2468-42d3-8ee4-52fc0739346e/_apis/work/boardbadge/3999b310-d315-40f5-822a-cd5c34495e90)](https://dev.azure.com/jackyao713911/1aefc37e-fcb0-4ee1-ace2-dc62de3257de/_boards/board/t/574ef8e2-2468-42d3-8ee4-52fc0739346e/Microsoft.RequirementCategory)
 # LinuxAutoShell
 
 # git config


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/jackyao713911/1aefc37e-fcb0-4ee1-ace2-dc62de3257de/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.